### PR TITLE
Stub modules for roadmap step 7

### DIFF
--- a/CodeCopier/Sources/CodeCopierCLI/main.swift
+++ b/CodeCopier/Sources/CodeCopierCLI/main.swift
@@ -1,0 +1,8 @@
+import ArgumentParser
+
+@main
+struct CodeCopierCLI: ParsableCommand {
+    mutating func run() throws {
+        print("CodeCopier CLI")
+    }
+}

--- a/CodeCopier/Sources/CodeCopierCore/AggregationAPI.swift
+++ b/CodeCopier/Sources/CodeCopierCore/AggregationAPI.swift
@@ -1,0 +1,7 @@
+public protocol SourceAggregator {
+    func aggregate(_ files: [FileInfo], split: Int, includeTOC: Bool) async throws -> [String]
+}
+
+public struct FileInfo {
+    public let path: String
+}

--- a/CodeCopier/Sources/CodeCopierCore/AppDataStore.swift
+++ b/CodeCopier/Sources/CodeCopierCore/AppDataStore.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public actor AppDataStore {
+    public init() {}
+}

--- a/CodeCopier/Sources/CodeCopierCore/BrandColors.swift
+++ b/CodeCopier/Sources/CodeCopierCore/BrandColors.swift
@@ -1,0 +1,5 @@
+import SwiftUI
+
+public enum BrandColors {
+    public static let accent = Color(red: 0.11, green: 0.46, blue: 0.98)
+}

--- a/CodeCopier/Sources/CodeCopierCore/DashboardViewModel.swift
+++ b/CodeCopier/Sources/CodeCopierCore/DashboardViewModel.swift
@@ -1,0 +1,6 @@
+import Observation
+
+@Observable
+public final class DashboardViewModel {
+    public init() {}
+}

--- a/CodeCopier/Sources/CodeCopierCore/FileScanning.swift
+++ b/CodeCopier/Sources/CodeCopierCore/FileScanning.swift
@@ -1,0 +1,7 @@
+public protocol FileScanning {
+    func scan(url: URL) -> AsyncStream<FileMeta>
+}
+
+public struct FileMeta {
+    public let url: URL
+}

--- a/CodeCopier/Sources/CodeCopierCore/TokenService.swift
+++ b/CodeCopier/Sources/CodeCopierCore/TokenService.swift
@@ -1,0 +1,6 @@
+public actor TokenService {
+    public init() {}
+    public func tokenize(_ text: String) async -> [Int] {
+        return []
+    }
+}

--- a/CodeCopier/Sources/CodeCopierUI/main.swift
+++ b/CodeCopier/Sources/CodeCopierUI/main.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct CodeCopierApp: App {
+    var body: some Scene {
+        WindowGroup {
+            Text("CodeCopier UI")
+        }
+    }
+}

--- a/CodeCopier/Sources/Plugins/ReleaseDmgPlugin/ReleaseDmgPlugin.swift
+++ b/CodeCopier/Sources/Plugins/ReleaseDmgPlugin/ReleaseDmgPlugin.swift
@@ -1,0 +1,8 @@
+import PackagePlugin
+
+@main
+struct ReleaseDmgPlugin: BuildToolPlugin {
+    func createBuildCommands(context: PluginContext, target: Target) throws -> [Command] {
+        return []
+    }
+}

--- a/CodeCopier/Tests/CLITests/CLITests.swift
+++ b/CodeCopier/Tests/CLITests/CLITests.swift
@@ -1,0 +1,7 @@
+import XCTest
+
+final class CLITests: XCTestCase {
+    func testExample() {
+        XCTAssertTrue(true)
+    }
+}

--- a/CodeCopier/Tests/CoreTests/CoreTests.swift
+++ b/CodeCopier/Tests/CoreTests/CoreTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import CodeCopierCore
+
+final class CoreTests: XCTestCase {
+    func testStub() {
+        XCTAssertTrue(true)
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -34,8 +34,8 @@ let package = Package(
                 // .product(name: "AsyncAlgorithms", package: "swift-async-algorithms"), // REMOVED
                 "Tiktoken"
             ],
-            resources: [.process("Assets.xcassets")],
             path: "CodeCopier/Sources/CodeCopierUI",
+            resources: [.process("Assets.xcassets")],
             swiftSettings: [.enableExperimentalFeature("StrictConcurrency")]
         ),
         .target(


### PR DESCRIPTION
## Summary
- remove old `CodeCopier` submodule
- add `CodeCopier` directory with basic CLI, UI, and core targets
- define placeholder protocols and actors
- stub basic tests
- fix manifest target order

## Testing
- `swift test -v` *(fails: package dependencies can't be fetched)*