### PR TITLE
Implement CI docs infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Swift
+        uses: swift-actions/setup-swift@v1
+        with:
+          swift-version: '6.1'
+      - name: Install SwiftLint
+        run: brew install swiftlint
+      - name: SwiftLint
+        run: swiftlint
+      - name: Run tests
+        run: swift test --enable-code-coverage
+      - name: Check coverage
+        run: |
+          COVERAGE=$(swift test --enable-code-coverage --show-code-coverage 2>/dev/null | tail -n 1 | awk '{print $NF}' | tr -d '%')
+          echo "coverage=$COVERAGE" >> $GITHUB_OUTPUT
+          if [ -z "$COVERAGE" ] || [ "$COVERAGE" -lt 90 ]; then
+            echo "Test coverage below required threshold" >&2
+            exit 1
+          fi
+      - name: Build DocC
+        run: swift package --allow-writing-to-directory docs generate-documentation --output-path docs

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,11 @@
+opt_in_rules:
+  - todo
+  - trailing_whitespace
+  - type_body_length
+
+included:
+  - CodeCopier
+
+excluded:
+  - .build
+  - docs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+# Contributing
+
+Thank you for considering a contribution to CodeCopier! This project follows a lightweight GitHub flow with a preference for small, focused pull requests.
+
+## Development Setup
+1. Install Xcode 15 or later.
+2. Clone the repository and run `swift build` to fetch dependencies.
+3. Run `swiftlint` before committing. A GitHub Action enforces linting and unit tests on every pull request.
+
+## Pull Request Process
+- Fork the repository and create a feature branch.
+- Include relevant unit tests for any new code.
+- Ensure `swift test --enable-code-coverage` succeeds locally.
+- Submit the pull request. CI will fail if SwiftLint warnings are present or code coverage drops below 90%.
+
+We appreciate all feedback and fixes! For larger changes, please open an issue first to discuss the approach.

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -1,0 +1,23 @@
+# Architecture Overview
+
+This document describes the planned modular layout for CodeCopier based on the refactor roadmap. The project follows a service-oriented approach with Swift actors used for concurrency.
+
+## Modules
+- **CodeCopierCore** – houses the data models and core business logic.
+- **CodeCopierCLI** – command line interface target that depends on `CodeCopierCore`.
+- **CodeCopierUI** – SwiftUI-based macOS application target.
+
+## Concurrency Model
+Services such as `FileScannerService`, `Aggregator`, and `TokenService` are implemented as actors. `AppDataStore` is a single actor responsible for persistence. The UI communicates with these services via async calls to ensure tasks never block the main thread.
+
+## Data Flow
+```mermaid
+graph TD;
+  AppShellView -->|Observation| DashboardViewModel;
+  DashboardViewModel -->|async| FileScannerService;
+  DashboardViewModel -->|async| Aggregator;
+  DashboardViewModel -->|async| TokenService;
+  DashboardViewModel -->|async| AppDataStore;
+```
+
+Each service publishes progress updates through `Observable` properties which the `DashboardViewModel` observes.


### PR DESCRIPTION
## Summary
- set up GitHub Actions workflow running SwiftLint, tests and DocC
- add developer guidelines in CONTRIBUTING
- document the planned architecture
- provide SwiftLint configuration

## Testing
- `swift test` *(fails: argument 'path' must precede argument 'resources')*